### PR TITLE
Add transform utility method to destroy all children of transform

### DIFF
--- a/Assets/Src/Library/Runtime/Extensions/Transform.meta
+++ b/Assets/Src/Library/Runtime/Extensions/Transform.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: be707065ac7fc4fd5a4aa1deedf1fce1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Src/Library/Runtime/Extensions/Transform/Utils.cs
+++ b/Assets/Src/Library/Runtime/Extensions/Transform/Utils.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace CodeBlaze.Library.Extensions
+{
+    public static class Utils
+    {
+        /// <summary>
+        /// Destroy all children of transform 
+        /// </summary>
+        /// <param name="transform"></param>
+        /// <returns></returns>
+        public static Transform Clear(this Transform transform)
+        {
+            foreach (Transform child in transform)
+            {
+                Object.Destroy(child.gameObject);
+            }
+
+            return transform;
+        }
+    }
+}

--- a/Assets/Src/Library/Runtime/Extensions/Transform/Utils.cs.meta
+++ b/Assets/Src/Library/Runtime/Extensions/Transform/Utils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7a3655dcfaa744d7a2ccd2683cab82bd
+timeCreated: 1606487182


### PR DESCRIPTION
Create an extension for transform to destroy all the children.

Call directly with any transform like below.

`transform.Clear();`