### PR TITLE
Transform utility method

### DIFF
--- a/Assets/Src/Library/Runtime/Extensions/Transform/Utils.cs
+++ b/Assets/Src/Library/Runtime/Extensions/Transform/Utils.cs
@@ -18,5 +18,24 @@ namespace CodeBlaze.Library.Extensions
 
             return transform;
         }
+
+        /// <summary>
+        /// Destroy all children of type T
+        /// </summary>
+        /// <param name="transform"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Transform Clear<T>(this Transform transform)
+        {
+            foreach (Transform child in transform)
+            {
+                if (child.GetComponent<T>() != null)
+                {
+                    Object.Destroy(child.gameObject);
+                }
+            }
+
+            return transform;
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [1.5.0](https://github.com/dharmeshmp/CodeBlazeLibrary/compare/v1.4.1...v1.5.0) (2020-12-03)
-
-
-### Features
-
-* Merge pull request [#27](https://github.com/dharmeshmp/CodeBlazeLibrary/issues/27) from dharmeshmp/main ([e9efe5a](https://github.com/dharmeshmp/CodeBlazeLibrary/commit/e9efe5a0ef711a5f582fbb1de34037b51987355e))
-
 # [1.5.0](https://github.com/BLaZeKiLL/CodeBlazeLibrary/compare/v1.4.1...v1.5.0) (2020-11-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.5.0](https://github.com/dharmeshmp/CodeBlazeLibrary/compare/v1.4.1...v1.5.0) (2020-12-03)
+
+
+### Features
+
+* Merge pull request [#27](https://github.com/dharmeshmp/CodeBlazeLibrary/issues/27) from dharmeshmp/main ([e9efe5a](https://github.com/dharmeshmp/CodeBlazeLibrary/commit/e9efe5a0ef711a5f582fbb1de34037b51987355e))
+
 # [1.5.0](https://github.com/BLaZeKiLL/CodeBlazeLibrary/compare/v1.4.1...v1.5.0) (2020-11-28)
 
 


### PR DESCRIPTION
New utility method to clear all the child containing type T.

Usage

`transform.Clear<Image>();`

This will destroy all GameObjects which contain the Image component.